### PR TITLE
Fix #54: Filter out invalid/unplayable stream URLs

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -9,6 +9,32 @@ import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip19/hrps.dart';
 import 'package:ndk/shared/nips/nip19/nip19.dart';
 
+/// Check if a stream URL is valid (not localhost or unreachable addresses)
+bool isValidStreamUrl(String? url) {
+  if (url == null || url.isEmpty) return false;
+
+  final lowerUrl = url.toLowerCase();
+
+  // Block localhost variations
+  if (lowerUrl.contains('localhost') ||
+      lowerUrl.contains('127.0.0.1') ||
+      lowerUrl.contains('::1') ||
+      lowerUrl.contains('0.0.0.0')) {
+    return false;
+  }
+
+  // Block private IP ranges (simplified check)
+  final privateIpPattern = RegExp(
+    r'^https?://(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)',
+    caseSensitive: false,
+  );
+  if (privateIpPattern.hasMatch(url)) {
+    return false;
+  }
+
+  return true;
+}
+
 /// Container class over event and stream info
 class StreamEvent {
   late final StreamInfo info;

--- a/lib/widgets/stream_grid.dart
+++ b/lib/widgets/stream_grid.dart
@@ -27,6 +27,7 @@ class StreamGrid extends StatelessWidget {
         events
             .map((e) => StreamEvent(e))
             .where((e) => e.info.stream?.contains(".m3u8") ?? false)
+            .where((e) => isValidStreamUrl(e.info.stream))
             .where(
               (e) =>
                   (e.info.starts ?? e.event.createdAt) <=


### PR DESCRIPTION
## Summary
Added validation to filter out streams with unreachable addresses like localhost, 127.0.0.1, and private IP ranges. This keeps the stream list clean and only shows playable content.

## Changes made
- Added  function in  to validate stream URLs
- Updated  widget in  to filter out invalid streams

## Technical details
The validation blocks:
- localhost and 127.0.0.1
- IPv6 loopback (::1)
- 0.0.0.0
- Private IP ranges (10.x.x.x, 172.16-31.x.x, 192.168.x.x)

Closes #54