### PR TITLE
fix(chat): stop message list reordering and anchor overlays to the input

### DIFF
--- a/lib/rx_filter.dart
+++ b/lib/rx_filter.dart
@@ -84,7 +84,10 @@ class RxFilterState<T> extends ChangeNotifier
   final bool leaveOpen;
   final T Function(Nip01Event)? mapper;
   final List<String>? relays;
-  HashMap<String, (int, T)>? _events;
+  /// Insertion-ordered so consumers see a stable sequence between updates;
+  /// an unordered map lets equal-timestamp events swap places on every
+  /// notification and the list they render jumps around.
+  LinkedHashMap<String, (int, T)>? _events;
   late final NdkResponse _response;
   late final StreamSubscription _listener;
 
@@ -134,7 +137,7 @@ class RxFilterState<T> extends ChangeNotifier
 
   bool _replaceInto(Nip01Event ev) {
     final evKey = _eventKey(ev);
-    _events ??= HashMap();
+    _events ??= LinkedHashMap();
     final existing = _events![evKey];
     if (existing == null || existing.$1 < ev.createdAt) {
       _events![evKey] = (ev.createdAt, mapper != null ? mapper!(ev) : ev as T);

--- a/lib/widgets/chat.dart
+++ b/lib/widgets/chat.dart
@@ -172,9 +172,20 @@ class _ChatWidget extends State<ChatWidget> {
                 })
                 // filter events that are created before stream start time
                 .where((e) => e.event.createdAt >= (stream.info.starts ?? 0))
-                .sortedBy((e) => e.event.createdAt)
+                // second-resolution timestamps tie constantly in a busy chat,
+                // so the id breaks the tie: without it equal-timestamp
+                // messages reorder between rebuilds and the list jumps
+                .sorted(
+                  (a, b) => a.event.createdAt == b.event.createdAt
+                      ? a.event.id.compareTo(b.event.id)
+                      : a.event.createdAt.compareTo(b.event.createdAt),
+                )
                 .reversed
                 .toList();
+
+        final indexOfEventId = {
+          for (final (idx, e) in filteredChat.indexed) e.event.id: idx,
+        };
 
         final zaps =
             filteredChat.where((e) => e.isZap()).map((e) => e.zap).toList();
@@ -208,6 +219,14 @@ class _ChatWidget extends State<ChatWidget> {
                 padding: EdgeInsets.only(top: 80),
                 reverse: true,
                 itemCount: filteredChat.length,
+                // messages arrive at both ends of the window, so match
+                // existing elements by key instead of by index, otherwise
+                // every insert re-homes the widgets below it and the visible
+                // rows shuffle
+                findChildIndexCallback: (key) {
+                  if (key is! ValueKey<String>) return null;
+                  return indexOfEventId[key.value.split(":").last];
+                },
                 itemBuilder: (ctx, idx) {
                   final msg = filteredChat[idx];
                   final widget = switch (msg.event.kind) {

--- a/lib/widgets/chat_write.dart
+++ b/lib/widgets/chat_write.dart
@@ -25,6 +25,7 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
   late FocusNode _focusNode;
   List<List<String>> _tags = List.empty(growable: true);
   final GlobalKey _positioned = GlobalKey();
+  final LayerLink _inputLink = LayerLink();
 
   @override
   void initState() {
@@ -53,6 +54,7 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
       _entry!.remove();
     }
     _controller.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -68,12 +70,6 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
       _entry!.remove();
       _entry = null;
     }
-
-    final RenderBox? textFieldBox = _focusNode.context?.findRenderObject() as RenderBox?;
-    if (textFieldBox == null) return;
-
-    final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-    final Offset textFieldPosition = textFieldBox.localToGlobal(Offset.zero, ancestor: overlay);
 
     _entry = OverlayEntry(
       builder: (context) {
@@ -91,10 +87,14 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
               return const SizedBox();
             }
             return Positioned(
-              left: textFieldPosition.dx,
-              top: textFieldPosition.dy + textFieldBox.size.height,
-              width: textFieldBox.size.width,
-              child: Container(
+              width: _inputWidth,
+              child: CompositedTransformFollower(
+                link: _inputLink,
+                showWhenUnlinked: false,
+                targetAnchor: Alignment.topLeft,
+                followerAnchor: Alignment.bottomLeft,
+                offset: const Offset(0, -4),
+                child: Container(
                 padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
                 decoration: BoxDecoration(
                   color: LAYER_2,
@@ -142,6 +142,7 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
                     );
                   },
                 ),
+                ),
               ),
             );
           },
@@ -151,25 +152,27 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
     Overlay.of(context).insert(_entry!);
   }
 
+  /// Width of the message input, so an overlay anchored to it lines up.
+  double? get _inputWidth =>
+      (_positioned.currentContext?.findRenderObject() as RenderBox?)?.size.width;
+
   void _showEmojiPicker() {
     if (_entry != null) {
       _entry!.remove();
       _entry = null;
     }
 
-    final RenderBox? textFieldBox = _focusNode.context?.findRenderObject() as RenderBox?;
-    if (textFieldBox == null) return;
-
-    final RenderBox overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-    final Offset textFieldPosition = textFieldBox.localToGlobal(Offset.zero, ancestor: overlay);
-
     _entry = OverlayEntry(
       builder: (context) {
         return Positioned(
-          left: textFieldPosition.dx,
-          top: textFieldPosition.dy + textFieldBox.size.height,
-          width: textFieldBox.size.width,
-          child: Container(
+          width: _inputWidth,
+          child: CompositedTransformFollower(
+            link: _inputLink,
+            showWhenUnlinked: false,
+            targetAnchor: Alignment.topLeft,
+            followerAnchor: Alignment.bottomLeft,
+            offset: const Offset(0, -4),
+            child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
             decoration: BoxDecoration(
               color: LAYER_2,
@@ -186,6 +189,7 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
                   });
                 }
               },
+            ),
             ),
           ),
         );
@@ -227,7 +231,9 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
     final canSign = ndk.accounts.canSign;
     final isLogin = ndk.accounts.isLoggedIn;
 
-    return Container(
+    return CompositedTransformTarget(
+      link: _inputLink,
+      child: Container(
       key: _positioned,
       margin: const EdgeInsets.fromLTRB(4, 8, 4, 0),
       padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -287,6 +293,7 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
                 ],
               ),
             ),
+      ),
     );
   }
 }

--- a/lib/widgets/chat_write.dart
+++ b/lib/widgets/chat_write.dart
@@ -95,53 +95,60 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
                 followerAnchor: Alignment.bottomLeft,
                 offset: const Offset(0, -4),
                 child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-                decoration: BoxDecoration(
-                  color: LAYER_2,
-                  borderRadius: DEFAULT_BR,
-                ),
-                child: FutureBuilder(
-                  future: ndkCache.searchMetadatas(search, 5),
-                  builder: (context, state) {
-                    if (state.data?.isEmpty ?? true) {
-                      return Text(t.no_user_found);
-                    }
-                    return Column(
-                      spacing: 4,
-                      children: (state.data ?? [])
-                          .groupListsBy((m) => m.pubKey)
-                          .entries
-                          .map(
-                            (m) => GestureDetector(
-                              onTap: () {
-                                _controller.text = _controller.text.replaceRange(
-                                  selectionStart,
-                                  _controller.text.length,
-                                  "nostr:${Nip19.encodePubKey(m.value.first.pubKey)}",
-                                );
-                                _entry!.remove();
-                                _entry = null;
-                              },
-                              child: Row(
-                                spacing: 4,
-                                children: [
-                                  AvatarWidget(
-                                    profile: m.value.first,
-                                    size: 30,
-                                  ),
-                                  Expanded(
-                                    child: Text(
-                                      ProfileNameWidget.nameFromProfile(m.value.first),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 4,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: LAYER_2,
+                    borderRadius: DEFAULT_BR,
+                  ),
+                  child: FutureBuilder(
+                    future: ndkCache.searchMetadatas(search, 5),
+                    builder: (context, state) {
+                      if (state.data?.isEmpty ?? true) {
+                        return Text(t.no_user_found);
+                      }
+                      return Column(
+                        spacing: 4,
+                        children:
+                            (state.data ?? [])
+                                .groupListsBy((m) => m.pubKey)
+                                .entries
+                                .map(
+                                  (m) => GestureDetector(
+                                    onTap: () {
+                                      _controller
+                                          .text = _controller.text.replaceRange(
+                                        selectionStart,
+                                        _controller.text.length,
+                                        "nostr:${Nip19.encodePubKey(m.value.first.pubKey)}",
+                                      );
+                                      _entry!.remove();
+                                      _entry = null;
+                                    },
+                                    child: Row(
+                                      spacing: 4,
+                                      children: [
+                                        AvatarWidget(
+                                          profile: m.value.first,
+                                          size: 30,
+                                        ),
+                                        Expanded(
+                                          child: Text(
+                                            ProfileNameWidget.nameFromProfile(
+                                              m.value.first,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
                                     ),
                                   ),
-                                ],
-                              ),
-                            ),
-                          )
-                          .toList(),
-                    );
-                  },
-                ),
+                                )
+                                .toList(),
+                      );
+                    },
+                  ),
                 ),
               ),
             );
@@ -154,7 +161,9 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
 
   /// Width of the message input, so an overlay anchored to it lines up.
   double? get _inputWidth =>
-      (_positioned.currentContext?.findRenderObject() as RenderBox?)?.size.width;
+      (_positioned.currentContext?.findRenderObject() as RenderBox?)
+          ?.size
+          .width;
 
   void _showEmojiPicker() {
     if (_entry != null) {
@@ -173,23 +182,29 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
             followerAnchor: Alignment.bottomLeft,
             offset: const Offset(0, -4),
             child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-            decoration: BoxDecoration(
-              color: LAYER_2,
-              borderRadius: DEFAULT_BR,
-            ),
-            child: EmojiPickerCustom(
-              customEmojiSets: [widget.stream.info.host],
-              onEmojiSelected: (emoji) {
-                _controller.text = _controller.text +
-                    (emoji.emoji.startsWith("http") ? ":${emoji.name}:" : emoji.emoji);
-                if (emoji.emoji.startsWith("http")) {
-                  setState(() {
-                    _tags = [..._tags, ["emoji", emoji.name, emoji.emoji]];
-                  });
-                }
-              },
-            ),
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+              decoration: BoxDecoration(
+                color: LAYER_2,
+                borderRadius: DEFAULT_BR,
+              ),
+              child: EmojiPickerCustom(
+                customEmojiSets: [widget.stream.info.host],
+                onEmojiSelected: (emoji) {
+                  _controller.text =
+                      _controller.text +
+                      (emoji.emoji.startsWith("http")
+                          ? ":${emoji.name}:"
+                          : emoji.emoji);
+                  if (emoji.emoji.startsWith("http")) {
+                    setState(() {
+                      _tags = [
+                        ..._tags,
+                        ["emoji", emoji.name, emoji.emoji],
+                      ];
+                    });
+                  }
+                },
+              ),
             ),
           ),
         );
@@ -234,65 +249,70 @@ class __WriteMessageWidget extends State<WriteMessageWidget> {
     return CompositedTransformTarget(
       link: _inputLink,
       child: Container(
-      key: _positioned,
-      margin: const EdgeInsets.fromLTRB(4, 8, 4, 0),
-      padding: const EdgeInsets.symmetric(horizontal: 8),
-      decoration: BoxDecoration(
-        color: LAYER_2.withAlpha(200),
-        borderRadius: DEFAULT_BR,
-      ),
-      child: canSign
-          ? Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    maxLines: 3,
-                    minLines: 1,
-                    focusNode: _focusNode,
-                    controller: _controller,
-                    onSubmitted: (_) => _sendMessage(context),
-                    onTapOutside: (event) {
-                      if (_entry == null) {
-                        _focusNode.unfocus();
-                      }
-                    },
-                    decoration: InputDecoration(
-                       labelText: t.stream.chat.write.label,
-                       contentPadding: const EdgeInsets.symmetric(vertical: 4),
-                       labelStyle: TextStyle(color: LAYER_4, fontSize: 14),
-                       border: InputBorder.none,
-                     ),
+        key: _positioned,
+        margin: const EdgeInsets.fromLTRB(4, 8, 4, 0),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        decoration: BoxDecoration(
+          color: LAYER_2.withAlpha(200),
+          borderRadius: DEFAULT_BR,
+        ),
+        child:
+            canSign
+                ? Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        maxLines: 3,
+                        minLines: 1,
+                        focusNode: _focusNode,
+                        controller: _controller,
+                        onSubmitted: (_) => _sendMessage(context),
+                        onTapOutside: (event) {
+                          if (_entry == null) {
+                            _focusNode.unfocus();
+                          }
+                        },
+                        decoration: InputDecoration(
+                          labelText: t.stream.chat.write.label,
+                          contentPadding: const EdgeInsets.symmetric(
+                            vertical: 4,
+                          ),
+                          labelStyle: TextStyle(color: LAYER_4, fontSize: 14),
+                          border: InputBorder.none,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        if (_entry != null) {
+                          _entry!.remove();
+                          _entry = null;
+                        } else {
+                          _showEmojiPicker();
+                        }
+                      },
+                      icon: const Icon(Icons.mood),
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        _sendMessage(context);
+                      },
+                      icon: const Icon(Icons.send),
+                    ),
+                  ],
+                )
+                : Container(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Row(
+                    children: [
+                      Text(
+                        isLogin
+                            ? t.stream.chat.write.no_signer
+                            : t.stream.chat.write.login,
+                      ),
+                    ],
                   ),
                 ),
-                IconButton(
-                  onPressed: () {
-                    if (_entry != null) {
-                      _entry!.remove();
-                      _entry = null;
-                    } else {
-                      _showEmojiPicker();
-                    }
-                  },
-                  icon: const Icon(Icons.mood),
-                ),
-                IconButton(
-                  onPressed: () {
-                    _sendMessage(context);
-                  },
-                  icon: const Icon(Icons.send),
-                ),
-              ],
-            )
-          : Container(
-              padding: const EdgeInsets.symmetric(vertical: 12),
-              child: Row(
-                children: [
-                  Text(
-                    isLogin ? t.stream.chat.write.no_signer : t.stream.chat.write.login,
-                  ),
-                ],
-              ),
-            ),
       ),
     );
   }


### PR DESCRIPTION
Fixes #36 and #48.

**#36 — chat bounces.** `RxFilterState.value` returned `HashMap` iteration order (lib/rx_filter.dart:90), and `chat.dart` sorted only on `createdAt`, which is second-resolution. Equal-timestamp messages therefore got an arbitrary relative order that changed on every relay update. Now the store is insertion-ordered and the sort tie-breaks on event id, plus `findChildIndexCallback` so the sliver matches existing elements by key instead of index.

**#48 — mention overlay out of place.** The overlay position was computed once from a stale `localToGlobal` and placed *below* the input (lib/widgets/chat_write.dart), which is under the keyboard when the input sits at the bottom. Replaced with `LayerLink` + `CompositedTransformFollower` anchored above the input, so it tracks the field through keyboard and size changes. Same for the emoji picker. Also disposes `_focusNode`.

Not run locally: no flutter toolchain on this machine, so the CI analyze gate is the only check so far. Behaviour needs a device check on a busy chat.